### PR TITLE
Symlink path fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ editor. If your ledger file has the `.ledger` suffix, you should be fine.
 
 ```bash
 git clone https://github.com/whereswaldon/ledger.kak
-ln -sv $PWD/kakdown/ledger.kak ~/.config/kak/autoload/
+ln -sv $PWD/ledger.kak/ledger.kak ~/.config/kak/autoload/
 ```
 
 **Note:** If this is your first time installing a Kakoune plugin and you don't already


### PR DESCRIPTION
The symlink command in the installation instructions seemed to be pointing at an obsolete repository name. The command now uses the correct real path.